### PR TITLE
Make canvas responsive

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -344,11 +344,14 @@
     gap: 12px;
     justify-items: start;
     padding: 12px;
+    width: 100%;
   }
   canvas {
     image-rendering: crisp-edges;
     border-radius: 10px;
     box-shadow: 0 6px 24px rgba(0,0,0,.25);
+    max-width: 100%;
+    height: auto;
   }
   .hud {
     display: flex;


### PR DESCRIPTION
## Summary
- Allow App canvas to shrink with viewport by setting `max-width: 100%` and `height: auto` on the canvas element
- Ensure parent `.wrap` container can shrink to fit smaller screens

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68994eae2b9c8321bef5b93d169b1c46