### PR TITLE
Increase max flick distance for full power drag

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -11,7 +11,7 @@
   const WALL_THICK = 40;
   const DISC_R = 18;
   const BALL_R = 10;
-  const MAX_FLICK = 12;
+  const MAX_FLICK = 24;
   const LINEAR_DAMPING = 0.025;
   const STOP_EPS = 0.03;
   const GOAL_WIDTH = 160;


### PR DESCRIPTION
## Summary
- double `MAX_FLICK` constant so flicks can span the full power range

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c035139ac8321bd65e91bec23023a