### PR TITLE
Increase player linear damping

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -12,7 +12,9 @@
   const DISC_R = 18;
   const BALL_R = 10;
   const MAX_FLICK = 24;
-  const LINEAR_DAMPING = 0.025;
+  // Higher damping slows players faster while keeping the ball lively
+  const LINEAR_DAMPING = 0.05;
+  const BALL_LINEAR_DAMPING = 0.025;
   const STOP_EPS = 0.03;
   const GOAL_WIDTH = 160;
 
@@ -229,7 +231,7 @@
     // Ball
     ball = Bodies.circle(width/2, height/2, BALL_R, {
       restitution: 0.92,
-      frictionAir: LINEAR_DAMPING,
+      frictionAir: BALL_LINEAR_DAMPING,
       render: { fillStyle: '#fff', strokeStyle: '#111', lineWidth: 1.2 }
     });
 


### PR DESCRIPTION
## Summary
- increase player linear damping so pieces slow down faster
- keep original lower damping for the ball using a dedicated constant

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c0453225c832195c3bc46378025cd