### PR TITLE
feat: add custom damping for players

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -253,6 +253,20 @@
     Render.run(render);
 
     // Tick hooks
+    Events.on(engine, 'beforeUpdate', () => {
+      const threshold = 2;
+      const slow = 0.9;
+      const fast = 0.98;
+
+      for (const b of [...teamA, ...teamB]) {
+        const v = b.velocity;
+        const speed = Math.hypot(v.x, v.y);
+        const t = Math.min(speed / threshold, 1);
+        const scale = slow + (fast - slow) * t * t;
+        Body.setVelocity(b, { x: v.x * scale, y: v.y * scale });
+      }
+    });
+
     Events.on(engine, 'afterUpdate', () => {
       checkGoals();
       switchTurnIfSettle();


### PR DESCRIPTION
## Summary
- implement `beforeUpdate` hook to apply custom damping to player pieces
- scale velocity quadratically to retain high-speed responsiveness while reducing low-speed glide

## Testing
- `npm test` *(fails: Missing script: "test" )*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c1079c4f88321925641447f2e208a